### PR TITLE
Fix README API credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ The backend server will start on http://localhost:8080
 ### API Endpoints
 - H2 Console: http://localhost:8080/h2-console
   - Database URL: jdbc:h2:mem:demodb
-  - Username: SA
-  - Password: (empty)
+  - Username: sa
+  - Password: password
 
 ## Frontend (React)
 


### PR DESCRIPTION
## Summary
- update database credentials in the root README's API Endpoints section

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684127d37b4483279e76d86b49963abd