### PR TITLE
Add ItemService tests

### DIFF
--- a/backend-api/src/main/java/com/example/demo/service/ItemService.java
+++ b/backend-api/src/main/java/com/example/demo/service/ItemService.java
@@ -29,6 +29,7 @@ public class ItemService {
         Item item = getItem(id);
         item.setName(itemDetails.getName());
         item.setDescription(itemDetails.getDescription());
+        item.setActive(itemDetails.isActive());
         return itemRepository.save(item);
     }
 

--- a/backend-api/src/test/java/com/example/demo/service/ItemServiceTest.java
+++ b/backend-api/src/test/java/com/example/demo/service/ItemServiceTest.java
@@ -1,0 +1,61 @@
+package com.example.demo.service;
+
+import com.example.demo.model.Item;
+import com.example.demo.repository.ItemRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class ItemServiceTest {
+
+    @Autowired
+    private ItemService itemService;
+
+    @Autowired
+    private ItemRepository itemRepository;
+
+    @Test
+    void testCreateItem() {
+        Item item = new Item();
+        item.setName("Test Item");
+        item.setDescription("Item description");
+        item.setActive(true);
+
+        Item saved = itemService.createItem(item);
+
+        assertNotNull(saved.getId());
+        assertEquals("Test Item", saved.getName());
+        assertEquals("Item description", saved.getDescription());
+        assertTrue(saved.isActive());
+        assertEquals(1, itemRepository.count());
+    }
+
+    @Test
+    void testUpdateItem() {
+        Item item = new Item();
+        item.setName("Original");
+        item.setDescription("Original description");
+        item.setActive(true);
+        Item saved = itemService.createItem(item);
+
+        Item updates = new Item();
+        updates.setName("Updated");
+        updates.setDescription("Updated description");
+        updates.setActive(false);
+
+        Item updated = itemService.updateItem(saved.getId(), updates);
+
+        assertEquals(saved.getId(), updated.getId());
+        assertEquals("Updated", updated.getName());
+        assertEquals("Updated description", updated.getDescription());
+        assertFalse(updated.isActive());
+
+        Item fromDb = itemService.getItem(saved.getId());
+        assertFalse(fromDb.isActive());
+    }
+}


### PR DESCRIPTION
## Summary
- add integration tests for ItemService
- update `ItemService.updateItem` to handle active field

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684127d7589883279c8e91f5695e1fea