### PR TITLE
Update ItemService and add tests

### DIFF
--- a/backend-api/src/main/java/com/example/demo/service/ItemService.java
+++ b/backend-api/src/main/java/com/example/demo/service/ItemService.java
@@ -29,6 +29,7 @@ public class ItemService {
         Item item = getItem(id);
         item.setName(itemDetails.getName());
         item.setDescription(itemDetails.getDescription());
+        item.setActive(itemDetails.isActive());
         return itemRepository.save(item);
     }
 

--- a/backend-api/src/test/java/com/example/demo/service/ItemServiceTest.java
+++ b/backend-api/src/test/java/com/example/demo/service/ItemServiceTest.java
@@ -1,0 +1,44 @@
+package com.example.demo.service;
+
+import com.example.demo.model.Item;
+import com.example.demo.repository.ItemRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ItemServiceTest {
+
+    @Mock
+    private ItemRepository itemRepository;
+
+    @InjectMocks
+    private ItemService itemService;
+
+    @Test
+    void updateItem_updatesActiveField() {
+        Item existing = new Item(1L, "old", "old desc", true);
+        Item updateDetails = new Item();
+        updateDetails.setName("new");
+        updateDetails.setDescription("new desc");
+        updateDetails.setActive(false);
+
+        when(itemRepository.findById(1L)).thenReturn(Optional.of(existing));
+        when(itemRepository.save(any(Item.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        Item result = itemService.updateItem(1L, updateDetails);
+
+        verify(itemRepository).save(existing);
+        assertEquals("new", result.getName());
+        assertEquals("new desc", result.getDescription());
+        assertFalse(result.isActive());
+    }
+}


### PR DESCRIPTION
## Summary
- update `updateItem` to also modify `active` flag
- add basic unit test for ItemService

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684127c7dbdc8327ba9bc769db3c4cc3